### PR TITLE
Avoid unnecessary features on rustls

### DIFF
--- a/crates/rustls-cert-reloadable-resolver/Cargo.toml
+++ b/crates/rustls-cert-reloadable-resolver/Cargo.toml
@@ -17,8 +17,9 @@ rustls-cert-read = { version = "0.3", path = "../rustls-cert-read" }
 
 async-trait = "0.1"
 futures-util = { version = "0.3", default-features = false }
-rustls = "0.23"
+rustls = { version = "0.23", default-features = false }
 thiserror = "2"
 
 [dev-dependencies]
+rustls = { version = "0.23", default-features = true }
 rustls-cert-file-reader = { version = "0.4", path = "../rustls-cert-file-reader" }


### PR DESCRIPTION
The current config forces the use of the `rustls` default features downstream which prevents us using rustls without the `aws-lc-*` dependencies. The PR adjusts the dependencies so that it includes only the minimum required.